### PR TITLE
Update slash

### DIFF
--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -263,6 +263,6 @@ where
 
 	fn slash(who: &AccountId, amount: Self::Balance) -> Self::Balance {
 		let (_, gap) = T::slash(who, amount);
-		amount - gap
+		gap
 	}
 }

--- a/currencies/src/tests.rs
+++ b/currencies/src/tests.rs
@@ -108,7 +108,7 @@ fn basic_currency_adapting_srml_balances_slash() {
 		.make_for_srml_balances()
 		.build()
 		.execute_with(|| {
-			assert_eq!(<BasicCurrencyAdapter<SrmlBalances>>::slash(&ALICE, 101), 100);
+			assert_eq!(<BasicCurrencyAdapter<SrmlBalances>>::slash(&ALICE, 101), 1);
 			assert_eq!(SrmlBalances::total_balance(&ALICE), 0);
 			assert_eq!(SrmlBalances::total_issuance(), 100);
 		});

--- a/currencies/src/tests.rs
+++ b/currencies/src/tests.rs
@@ -34,7 +34,7 @@ fn native_currency_should_work() {
 			assert_eq!(NativeCurrency::balance(&ALICE), 40);
 			assert_eq!(NativeCurrency::balance(&BOB), 160);
 
-			assert_eq!(Currencies::slash(NATIVE_CURRENCY_ID, &ALICE, 10), 10);
+			assert_eq!(Currencies::slash(NATIVE_CURRENCY_ID, &ALICE, 10), 0);
 			assert_eq!(NativeCurrency::balance(&ALICE), 30);
 			assert_eq!(NativeCurrency::total_issuance(), 190);
 		});

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -166,10 +166,10 @@ impl<T: Trait> MultiCurrency<T::AccountId> for Module<T> {
 	}
 
 	fn slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
-		let actual_amount = Self::balance(currency_id, who).min(amount);
-		<TotalIssuance<T>>::mutate(currency_id, |v| *v -= actual_amount);
-		<Balance<T>>::mutate(currency_id, who, |v| *v -= actual_amount);
-		actual_amount
+		let slashed_amount = Self::balance(currency_id, who).min(amount);
+		<TotalIssuance<T>>::mutate(currency_id, |v| *v -= slashed_amount);
+		<Balance<T>>::mutate(currency_id, who, |v| *v -= slashed_amount);
+		amount - slashed_amount
 	}
 }
 

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -71,6 +71,24 @@ fn withdraw_should_work() {
 }
 
 #[test]
+fn slash_should_work() {
+	ExtBuilder::default()
+		.one_hundred_for_alice_n_bob()
+		.build()
+		.execute_with(|| {
+			// slashed_amount < amount
+			assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 50), 0);
+			assert_eq!(Tokens::balance(TEST_TOKEN_ID, &ALICE), 50);
+			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 150);
+
+			// slashed_amount == amount
+			assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 51), 1);
+			assert_eq!(Tokens::balance(TEST_TOKEN_ID, &ALICE), 0);
+			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 100);
+		});
+}
+
+#[test]
 fn update_balance_should_work() {
 	ExtBuilder::default()
 		.one_hundred_for_alice_n_bob()

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -58,7 +58,8 @@ pub trait MultiCurrency<AccountId> {
 
 	/// Deduct the balance of `who` by up to `amount`.
 	///
-	/// As much funds up to `amount` will be deducted as possible, the actual slashed amount will be returned.
+	/// As much funds up to `amount` will be deducted as possible.  If this is less than `amount`,then a non-zero
+	/// value will be returned.
 	fn slash(currency_id: Self::CurrencyId, who: &AccountId, amount: Self::Balance) -> Self::Balance;
 }
 
@@ -112,7 +113,8 @@ pub trait BasicCurrency<AccountId> {
 
 	/// Deduct the balance of `who` by up to `amount`.
 	///
-	/// As much funds up to `amount` will be deducted as possible, the actual slashed amount will be returned.
+	/// As much funds up to `amount` will be deducted as possible. If this is less than `amount`,then a non-zero
+	/// value will be returned.
 	fn slash(who: &AccountId, amount: Self::Balance) -> Self::Balance;
 }
 


### PR DESCRIPTION
Make `slash` to return `amount - slashed_amount` instead of `amount`, to be consistent with `slash` in `srml_support::traits::Currency`.