### PR TITLE
add Debug bound to MultiCurrency::Error

### DIFF
--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -23,7 +23,7 @@ pub trait MultiCurrency<AccountId> {
 	type Balance: SimpleArithmetic + FullCodec + Copy + MaybeSerializeDeserialize + Debug + Default;
 
 	/// The error type.
-	type Error: Into<&'static str>;
+	type Error: Into<&'static str> + Debug;
 
 	// Public immutables
 


### PR DESCRIPTION
使用 expect 会抛出的错误
```
the method `expect` exists but the following trait bounds were not satisfied:
            `<<T as Trait>::Currency as orml_traits::MultiCurrency<<T as frame_system::Trait>::AccountId>>::Error : std::fmt::Debug`
```