### PR TITLE
Deps renaming

### DIFF
--- a/auction/Cargo.toml
+++ b/auction/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.5", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.5", default-features = false }
+sp-io = { version = "2.0.0-alpha.5", default-features = false }
+sp-std = { version = "2.0.0-alpha.5", default-features = false }
 
 frame-support = { version = "2.0.0-alpha.5", default-features = false }
 frame-system = { version = "2.0.0-alpha.5", default-features = false }
@@ -18,7 +18,7 @@ orml-traits = { path = "../traits", default-features = false }
 orml-utilities = { path = "../utilities", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.5", default-features = false }
+sp-core = { version = "2.0.0-alpha.5", default-features = false }
 
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
 
@@ -28,8 +28,8 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
-	"runtime-io/std",
-	"rstd/std",
+	"sp-io/std",
+	"sp-std/std",
 	"frame-support/std",
 	"frame-system/std",
 	"orml-traits/std",

--- a/auction/src/mock.rs
+++ b/auction/src/mock.rs
@@ -4,7 +4,7 @@
 
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use orml_traits::OnNewBidResult;
-use primitives::H256;
+use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
 use super::*;
@@ -98,7 +98,7 @@ impl Default for ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let t = frame_system::GenesisConfig::default()
 			.build_storage::<Runtime>()
 			.unwrap();

--- a/currencies/Cargo.toml
+++ b/currencies/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.5", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.5", default-features = false }
+sp-io = { version = "2.0.0-alpha.5", default-features = false }
+sp-std = { version = "2.0.0-alpha.5", default-features = false }
 
 frame-support = { version = "2.0.0-alpha.5", default-features = false }
 frame-system = { version = "2.0.0-alpha.5", default-features = false }
@@ -17,8 +17,8 @@ frame-system = { version = "2.0.0-alpha.5", default-features = false }
 orml-traits = { path = "../traits", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core", version = "2.0.0-alpha.5", default-features = false }
-pallet-balances = { package = "pallet-balances", version = "2.0.0-alpha.5" }
+sp-core = { version = "2.0.0-alpha.5", default-features = false }
+pallet-balances = { version = "2.0.0-alpha.5" }
 tokens = { package = "orml-tokens", path = "../tokens" }
 
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
@@ -29,8 +29,8 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
-	"rstd/std",
-	"runtime-io/std",
+	"sp-std/std",
+	"sp-io/std",
 	"frame-support/std",
 	"frame-system/std",
 	"orml-traits/std",

--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -38,11 +38,11 @@ use frame_support::{
 		ReservableCurrency as PalletReservableCurrency, WithdrawReason,
 	},
 };
-use rstd::{convert::TryInto, marker};
 use sp_runtime::{
 	traits::{CheckedSub, StaticLookup, Zero},
 	DispatchError, DispatchResult,
 };
+use sp_std::{convert::TryInto, marker};
 // FIXME: `pallet/frame-` prefix should be used for all pallet modules, but currently `frame_system`
 // would cause compiling error in `decl_module!` and `construct_runtime!`
 // #3295 https://github.com/paritytech/substrate/issues/3295
@@ -340,7 +340,7 @@ impl<T: Trait> MultiReservableCurrency<T::AccountId> for Module<T> {
 		beneficiary: &T::AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> rstd::result::Result<Self::Balance, DispatchError> {
+	) -> sp_std::result::Result<Self::Balance, DispatchError> {
 		if currency_id == T::GetNativeCurrencyId::get() {
 			T::NativeCurrency::repatriate_reserved(slashed, beneficiary, value, status)
 		} else {
@@ -457,7 +457,7 @@ where
 		beneficiary: &T::AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> rstd::result::Result<Self::Balance, DispatchError> {
+	) -> sp_std::result::Result<Self::Balance, DispatchError> {
 		<Module<T> as MultiReservableCurrency<T::AccountId>>::repatriate_reserved(
 			GetCurrencyId::get(),
 			slashed,
@@ -640,7 +640,7 @@ where
 		beneficiary: &AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> rstd::result::Result<Self::Balance, DispatchError> {
+	) -> sp_std::result::Result<Self::Balance, DispatchError> {
 		Currency::repatriate_reserved(slashed, beneficiary, BalanceConvert::from(value).into(), status.into())
 			.map(|a| BalanceConvert::from(a).into())
 	}

--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -42,7 +42,7 @@ use sp_runtime::{
 	traits::{CheckedSub, StaticLookup, Zero},
 	DispatchError, DispatchResult,
 };
-use sp_std::{convert::TryInto, marker};
+use sp_std::{convert::TryInto, marker, result};
 // FIXME: `pallet/frame-` prefix should be used for all pallet modules, but currently `frame_system`
 // would cause compiling error in `decl_module!` and `construct_runtime!`
 // #3295 https://github.com/paritytech/substrate/issues/3295
@@ -340,7 +340,7 @@ impl<T: Trait> MultiReservableCurrency<T::AccountId> for Module<T> {
 		beneficiary: &T::AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> sp_std::result::Result<Self::Balance, DispatchError> {
+	) -> result::Result<Self::Balance, DispatchError> {
 		if currency_id == T::GetNativeCurrencyId::get() {
 			T::NativeCurrency::repatriate_reserved(slashed, beneficiary, value, status)
 		} else {
@@ -457,7 +457,7 @@ where
 		beneficiary: &T::AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> sp_std::result::Result<Self::Balance, DispatchError> {
+	) -> result::Result<Self::Balance, DispatchError> {
 		<Module<T> as MultiReservableCurrency<T::AccountId>>::repatriate_reserved(
 			GetCurrencyId::get(),
 			slashed,
@@ -640,7 +640,7 @@ where
 		beneficiary: &AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> sp_std::result::Result<Self::Balance, DispatchError> {
+	) -> result::Result<Self::Balance, DispatchError> {
 		Currency::repatriate_reserved(slashed, beneficiary, BalanceConvert::from(value).into(), status.into())
 			.map(|a| BalanceConvert::from(a).into())
 	}

--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -4,7 +4,7 @@
 
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use pallet_balances;
-use primitives::H256;
+use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
 use tokens;
@@ -138,7 +138,7 @@ impl ExtBuilder {
 		])
 	}
 
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default()
 			.build_storage::<Runtime>()
 			.unwrap();

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.5", default-features = false }
+sp-io = { version = "2.0.0-alpha.5", default-features = false }
 sp-std = { version = "2.0.0-alpha.5", default-features = false }
 
 frame-support = { version = "2.0.0-alpha.5", default-features = false }
@@ -18,7 +18,7 @@ orml-traits = { path = "../traits", default-features = false }
 orml-utilities = { path = "../utilities", default-features = false }
 
 [dev-dependencies]
-primitives = { version = "2.0.0-alpha.5", package = "sp-core", default-features = false }
+sp-core = { version = "2.0.0-alpha.5", default-features = false }
 pallet-timestamp = { version = "2.0.0-alpha.5" }
 
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
@@ -29,7 +29,7 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
-	"runtime-io/std",
+	"sp-io/std",
 	"sp-std/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/oracle/src/default_combine_data.rs
+++ b/oracle/src/default_combine_data.rs
@@ -1,12 +1,12 @@
 use frame_support::traits::{Get, Time};
 use orml_traits::CombineData;
-use sp_std::prelude::*;
+use sp_std::{marker, prelude::*};
 
 use crate::{MomentOf, TimestampedValueOf, Trait};
 
 /// Sort by value and returns median timestamped value.
 /// Returns prev_value if not enough valid values.
-pub struct DefaultCombineData<T, MinimumCount, ExpiresIn>(sp_std::marker::PhantomData<(T, MinimumCount, ExpiresIn)>);
+pub struct DefaultCombineData<T, MinimumCount, ExpiresIn>(marker::PhantomData<(T, MinimumCount, ExpiresIn)>);
 
 impl<T, MinimumCount, ExpiresIn> CombineData<T::OracleKey, TimestampedValueOf<T>>
 	for DefaultCombineData<T, MinimumCount, ExpiresIn>

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -21,7 +21,7 @@ use sp_runtime::{
 	traits::{Member, SignedExtension},
 	DispatchResult,
 };
-use sp_std::{prelude::*, vec};
+use sp_std::{fmt, marker, prelude::*, result, vec};
 // FIXME: `pallet/frame-` prefix should be used for all pallet modules, but currently `frame_system`
 // would cause compiling error in `decl_module!` and `construct_runtime!`
 // #3295 https://github.com/paritytech/substrate/issues/3295
@@ -143,22 +143,22 @@ impl<T: Trait> Module<T> {
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq)]
-pub struct CheckOperator<T: Trait + Send + Sync>(sp_std::marker::PhantomData<T>);
+pub struct CheckOperator<T: Trait + Send + Sync>(marker::PhantomData<T>);
 
 impl<T: Trait + Send + Sync> CheckOperator<T> {
 	pub fn new() -> Self {
-		Self(sp_std::marker::PhantomData)
+		Self(marker::PhantomData)
 	}
 }
 
-impl<T: Trait + Send + Sync> sp_std::fmt::Debug for CheckOperator<T> {
+impl<T: Trait + Send + Sync> fmt::Debug for CheckOperator<T> {
 	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "CheckOperator")
 	}
 
 	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+	fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
 		Ok(())
 	}
 }
@@ -171,7 +171,7 @@ impl<T: Trait + Send + Sync> SignedExtension for CheckOperator<T> {
 	type Pre = ();
 	type DispatchInfo = DispatchInfo;
 
-	fn additional_signed(&self) -> sp_std::result::Result<(), TransactionValidityError> {
+	fn additional_signed(&self) -> result::Result<(), TransactionValidityError> {
 		Ok(())
 	}
 

--- a/oracle/src/mock.rs
+++ b/oracle/src/mock.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types, weights::Weight};
-use primitives::H256;
+use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -102,7 +102,7 @@ impl Trait for Test {
 pub type ModuleOracle = Module<Test>;
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
-pub fn new_test_ext() -> runtime_io::TestExternalities {
+pub fn new_test_ext() -> sp_io::TestExternalities {
 	let r = frame_system::GenesisConfig::default().build_storage::<Test>();
 
 	r.unwrap().into()

--- a/prices/Cargo.toml
+++ b/prices/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.5", default-features = false }
+sp-io = { version = "2.0.0-alpha.5", default-features = false }
 
 frame-support = { version = "2.0.0-alpha.5", default-features = false }
 frame-system = { version = "2.0.0-alpha.5", default-features = false }
@@ -17,7 +17,7 @@ orml-traits = { path = "../traits", default-features = false }
 orml-utilities = { path = "../utilities", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.5", default-features = false }
+sp-core = { version = "2.0.0-alpha.5", default-features = false }
 
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
 
@@ -26,7 +26,7 @@ default = ["std"]
 std = [
 	"serde",
 	"codec/std",
-	"runtime-io/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/prices/src/mock.rs
+++ b/prices/src/mock.rs
@@ -4,7 +4,7 @@
 
 use frame_support::{impl_outer_origin, parameter_types};
 use frame_system as system;
-use primitives::H256;
+use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
 use super::*;
@@ -78,7 +78,7 @@ impl Default for ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let t = frame_system::GenesisConfig::default()
 			.build_storage::<Runtime>()
 			.unwrap();

--- a/schedule-update/Cargo.toml
+++ b/schedule-update/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
-
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 
@@ -17,7 +16,6 @@ sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
 sp-io = { version = "2.0.0-alpha.5", default-features = false }
 sp-core = { version = "2.0.0-alpha.5", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.5", default-features = false }
-
 
 [features]
 default = ["std"]

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.5", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.5", default-features = false }
+sp-io = { version = "2.0.0-alpha.5", default-features = false }
+sp-std = { version = "2.0.0-alpha.5", default-features = false }
 
 frame-support = { version = "2.0.0-alpha.5", default-features = false }
 frame-system = { version = "2.0.0-alpha.5", default-features = false }
@@ -18,8 +18,7 @@ orml-traits = { path = "../traits", default-features = false }
 orml-utilities = { path = "../utilities", default-features = false }
 
 [dev-dependencies]
-primitives = { package = "sp-core",  version = "2.0.0-alpha.5", default-features = false }
-
+sp-core = { version = "2.0.0-alpha.5", default-features = false }
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
 
 [features]
@@ -28,8 +27,8 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
-	"rstd/std",
-	"runtime-io/std",
+	"sp-std/std",
+	"sp-io/std",
 	"frame-support/std",
 	"frame-system/std",
 	"orml-traits/std",

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -19,6 +19,7 @@ orml-utilities = { path = "../utilities", default-features = false }
 
 [dev-dependencies]
 sp-core = { version = "2.0.0-alpha.5", default-features = false }
+
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
 
 [features]

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -35,19 +35,19 @@
 
 use codec::{Decode, Encode};
 use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure, traits::Get, Parameter};
-use rstd::convert::{TryFrom, TryInto};
-use rstd::prelude::*;
 use sp_runtime::{
 	traits::{AtLeast32Bit, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Member, Saturating, StaticLookup, Zero},
 	DispatchError, DispatchResult, RuntimeDebug,
 };
+use sp_std::convert::{TryFrom, TryInto};
+use sp_std::prelude::*;
 // FIXME: `pallet/frame-` prefix should be used for all pallet modules, but currently `frame_system`
 // would cause compiling error in `decl_module!` and `construct_runtime!`
 // #3295 https://github.com/paritytech/substrate/issues/3295
 use frame_system::{self as system, ensure_signed};
 
 #[cfg(feature = "std")]
-use rstd::collections::btree_map::BTreeMap;
+use sp_std::collections::btree_map::BTreeMap;
 
 use orml_traits::{
 	arithmetic::{self, Signed},
@@ -551,7 +551,7 @@ impl<T: Trait> MultiReservableCurrency<T::AccountId> for Module<T> {
 		beneficiary: &T::AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> rstd::result::Result<Self::Balance, DispatchError> {
+	) -> sp_std::result::Result<Self::Balance, DispatchError> {
 		if value.is_zero() {
 			return Ok(Zero::zero());
 		}

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -39,8 +39,11 @@ use sp_runtime::{
 	traits::{AtLeast32Bit, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Member, Saturating, StaticLookup, Zero},
 	DispatchError, DispatchResult, RuntimeDebug,
 };
-use sp_std::convert::{TryFrom, TryInto};
-use sp_std::prelude::*;
+use sp_std::{
+	convert::{TryFrom, TryInto},
+	prelude::*,
+	result,
+};
 // FIXME: `pallet/frame-` prefix should be used for all pallet modules, but currently `frame_system`
 // would cause compiling error in `decl_module!` and `construct_runtime!`
 // #3295 https://github.com/paritytech/substrate/issues/3295
@@ -551,7 +554,7 @@ impl<T: Trait> MultiReservableCurrency<T::AccountId> for Module<T> {
 		beneficiary: &T::AccountId,
 		value: Self::Balance,
 		status: BalanceStatus,
-	) -> sp_std::result::Result<Self::Balance, DispatchError> {
+	) -> result::Result<Self::Balance, DispatchError> {
 		if value.is_zero() {
 			return Ok(Zero::zero());
 		}

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -4,9 +4,9 @@
 
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use frame_system as system;
-use primitives::H256;
-use rstd::{cell::RefCell, marker::PhantomData};
+use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
+use sp_std::{cell::RefCell, marker::PhantomData};
 
 use super::*;
 
@@ -122,7 +122,7 @@ impl ExtBuilder {
 		self.balances(vec![(ALICE, TEST_TOKEN_ID, 100), (BOB, TEST_TOKEN_ID, 100)])
 	}
 
-	pub fn build(self) -> runtime_io::TestExternalities {
+	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default()
 			.build_storage::<Runtime>()
 			.unwrap();

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.5", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.5", default-features = false }
+sp-io = { version = "2.0.0-alpha.5", default-features = false }
+sp-std = { version = "2.0.0-alpha.5", default-features = false }
 num-traits = { version = "0.2.11", default-features = false }
 impl-trait-for-tuples = "0.1.3"
 frame-support = { version = "2.0.0-alpha.5", default-features = false }
@@ -23,8 +23,8 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
-	"runtime-io/std",
-	"rstd/std",
+	"sp-io/std",
+	"sp-std/std",
 	"num-traits/std",
 	"frame-support/std",
 ]

--- a/traits/src/arithmetic.rs
+++ b/traits/src/arithmetic.rs
@@ -1,10 +1,10 @@
 pub use num_traits::{
 	Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedShl, CheckedShr, CheckedSub, One, Signed, Zero,
 };
-use sp_std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, Shr, Sub, SubAssign};
 use sp_std::{
 	self,
 	convert::{TryFrom, TryInto},
+	ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, Shr, Sub, SubAssign},
 };
 
 /// A meta trait for arithmetic.

--- a/traits/src/arithmetic.rs
+++ b/traits/src/arithmetic.rs
@@ -1,8 +1,8 @@
 pub use num_traits::{
 	Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedShl, CheckedShr, CheckedSub, One, Signed, Zero,
 };
-use rstd::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, Shr, Sub, SubAssign};
-use rstd::{
+use sp_std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, Shr, Sub, SubAssign};
+use sp_std::{
 	self,
 	convert::{TryFrom, TryInto},
 };

--- a/traits/src/auction.rs
+++ b/traits/src/auction.rs
@@ -1,12 +1,12 @@
 use codec::FullCodec;
 use codec::{Decode, Encode};
-use rstd::{
-	cmp::{Eq, PartialEq},
-	fmt::Debug,
-};
 use sp_runtime::{
 	traits::{AtLeast32Bit, MaybeSerializeDeserialize},
 	DispatchResult, RuntimeDebug,
+};
+use sp_std::{
+	cmp::{Eq, PartialEq},
+	fmt::Debug,
 };
 
 /// Auction info.

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -6,16 +6,16 @@ pub mod auction;
 pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
 use codec::{Codec, FullCodec};
 pub use frame_support::traits::{BalanceStatus, LockIdentifier};
-use rstd::{
+use sp_runtime::{
+	traits::{AtLeast32Bit, MaybeSerializeDeserialize},
+	DispatchError, DispatchResult,
+};
+use sp_std::{
 	cmp::{Eq, PartialEq},
 	convert::{TryFrom, TryInto},
 	fmt::Debug,
 	prelude::Vec,
 	result,
-};
-use sp_runtime::{
-	traits::{AtLeast32Bit, MaybeSerializeDeserialize},
-	DispatchError, DispatchResult,
 };
 
 /// Abstraction over a fungible multi-currency system.

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -17,6 +17,7 @@ frame-support = { version = "2.0.0-alpha.5", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.41"
+
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }	# https://github.com/paritytech/substrate/issues/4179
 
 [features]

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-primitives = { package = "sp-core",  version = "2.0.0-alpha.5", default-features = false }
+sp-core = { version = "2.0.0-alpha.5", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false }
-runtime-io = { package = "sp-io", version = "2.0.0-alpha.5", default-features = false }
-rstd = { package = "sp-std", version = "2.0.0-alpha.5", default-features = false }
+sp-io = { version = "2.0.0-alpha.5", default-features = false }
+sp-std = { version = "2.0.0-alpha.5", default-features = false }
 
 frame-system = { version = "2.0.0-alpha.5", default-features = false }
 frame-support = { version = "2.0.0-alpha.5", default-features = false }
@@ -25,8 +25,8 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
-	"runtime-io/std",
-	"rstd/std",
+	"sp-io/std",
+	"sp-std/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/utilities/src/fixed_128.rs
+++ b/utilities/src/fixed_128.rs
@@ -6,6 +6,7 @@ use sp_runtime::{
 };
 use sp_std::{
 	convert::{Into, TryFrom, TryInto},
+	fmt,
 	num::NonZeroI128,
 };
 
@@ -229,15 +230,15 @@ impl Bounded for Fixed128 {
 	}
 }
 
-impl sp_std::fmt::Debug for Fixed128 {
+impl fmt::Debug for Fixed128 {
 	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let fractional = format!("{:0>18}", (self.0 % DIV).abs());
 		write!(f, "Fixed128({},{})", self.0 / DIV, fractional)
 	}
 
 	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+	fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
 		Ok(())
 	}
 }

--- a/utilities/src/fixed_128.rs
+++ b/utilities/src/fixed_128.rs
@@ -1,12 +1,12 @@
 use codec::{Decode, Encode};
-use primitives::U256;
-use rstd::{
-	convert::{Into, TryFrom, TryInto},
-	num::NonZeroI128,
-};
+use sp_core::U256;
 use sp_runtime::{
 	traits::{Bounded, Saturating, UniqueSaturatedInto},
 	PerThing,
+};
+use sp_std::{
+	convert::{Into, TryFrom, TryInto},
+	num::NonZeroI128,
 };
 
 #[cfg(feature = "std")]
@@ -229,15 +229,15 @@ impl Bounded for Fixed128 {
 	}
 }
 
-impl rstd::fmt::Debug for Fixed128 {
+impl sp_std::fmt::Debug for Fixed128 {
 	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut rstd::fmt::Formatter) -> rstd::fmt::Result {
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		let fractional = format!("{:0>18}", (self.0 % DIV).abs());
 		write!(f, "Fixed128({},{})", self.0 / DIV, fractional)
 	}
 
 	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut rstd::fmt::Formatter) -> rstd::fmt::Result {
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
 }

--- a/utilities/src/fixed_u128.rs
+++ b/utilities/src/fixed_u128.rs
@@ -4,7 +4,10 @@ use sp_runtime::{
 	traits::{Bounded, Saturating, UniqueSaturatedInto},
 	PerThing,
 };
-use sp_std::convert::{Into, TryFrom, TryInto};
+use sp_std::{
+	convert::{Into, TryFrom, TryInto},
+	fmt,
+};
 
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -183,14 +186,14 @@ impl Bounded for FixedU128 {
 	}
 }
 
-impl sp_std::fmt::Debug for FixedU128 {
+impl fmt::Debug for FixedU128 {
 	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "FixedU128({},{})", self.0 / DIV, (self.0 % DIV) / 1000)
 	}
 
 	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+	fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
 		Ok(())
 	}
 }

--- a/utilities/src/fixed_u128.rs
+++ b/utilities/src/fixed_u128.rs
@@ -1,10 +1,10 @@
 use codec::{Decode, Encode};
-use primitives::U256;
-use rstd::convert::{Into, TryFrom, TryInto};
+use sp_core::U256;
 use sp_runtime::{
 	traits::{Bounded, Saturating, UniqueSaturatedInto},
 	PerThing,
 };
+use sp_std::convert::{Into, TryFrom, TryInto};
 
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -183,14 +183,14 @@ impl Bounded for FixedU128 {
 	}
 }
 
-impl rstd::fmt::Debug for FixedU128 {
+impl sp_std::fmt::Debug for FixedU128 {
 	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut rstd::fmt::Formatter) -> rstd::fmt::Result {
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "FixedU128({},{})", self.0 / DIV, (self.0 % DIV) / 1000)
 	}
 
 	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut rstd::fmt::Formatter) -> rstd::fmt::Result {
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
 }

--- a/utilities/src/linked_item.rs
+++ b/utilities/src/linked_item.rs
@@ -15,7 +15,7 @@ impl<Item> Default for LinkedItem<Item> {
 	}
 }
 
-pub struct LinkedList<Storage, Key, Item>(sp_std::marker::PhantomData<(Storage, Key, Item)>);
+pub struct LinkedList<Storage, Key, Item>(marker::PhantomData<(Storage, Key, Item)>);
 
 impl<Storage, Key, Value> LinkedList<Storage, Key, Value>
 where

--- a/utilities/src/linked_item.rs
+++ b/utilities/src/linked_item.rs
@@ -1,7 +1,7 @@
 use codec::{Decode, Encode};
 use frame_support::{Parameter, StorageMap};
-use rstd::{iter, marker, prelude::*};
 use sp_runtime::{traits::Member, RuntimeDebug};
+use sp_std::{iter, marker, prelude::*};
 
 #[derive(RuntimeDebug, PartialEq, Eq, Encode, Decode)]
 pub struct LinkedItem<Item> {
@@ -15,7 +15,7 @@ impl<Item> Default for LinkedItem<Item> {
 	}
 }
 
-pub struct LinkedList<Storage, Key, Item>(rstd::marker::PhantomData<(Storage, Key, Item)>);
+pub struct LinkedList<Storage, Key, Item>(sp_std::marker::PhantomData<(Storage, Key, Item)>);
 
 impl<Storage, Key, Value> LinkedList<Storage, Key, Value>
 where
@@ -161,7 +161,7 @@ mod tests {
 	use super::*;
 	use frame_support::{decl_module, decl_storage, impl_outer_origin, parameter_types, StorageMap};
 	use frame_system as system;
-	use primitives::H256;
+	use sp_core::H256;
 	use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
 	type Key = u64;
@@ -220,7 +220,7 @@ mod tests {
 
 	type TestLinkedList = LinkedList<TestItem, Key, Value>;
 
-	pub fn new_test_ext() -> runtime_io::TestExternalities {
+	pub fn new_test_ext() -> sp_io::TestExternalities {
 		frame_system::GenesisConfig::default()
 			.build_storage::<Test>()
 			.unwrap()


### PR DESCRIPTION
- `runtime-io` => `sp-io`
- `rstd` => `sp-std`
- combine multi `sp_std` imports into one